### PR TITLE
Fix for commas in attribute values

### DIFF
--- a/src/Everzet/Jade/Lexer/Lexer.php
+++ b/src/Everzet/Jade/Lexer/Lexer.php
@@ -308,12 +308,13 @@ class Lexer implements LexerInterface
             $index      = $this->getDelimitersIndex('(', ')');
             $input      = mb_substr($this->input, 1, $index - 1);
             $token      = $this->takeToken('attributes', $input);
-            $attributes = preg_split('/ *, *(?=[\'"\w-]+ *[:=]|[\w-]+ *$)/', $token->value);
+            $attributes = preg_split('/ *(?<!\\\\), *(?=[\'"\w-]+ *[:=]|[\w-]+ *$)/', $token->value);
             $this->consumeInput($index + 1);
             $token->attributes = array();
 
             foreach ($attributes as $i => $pair) {
                 $pair = preg_replace('/^ *| *$/', '', $pair);
+                $pair = str_replace('\,', ',', $pair);
                 $colon = mb_strpos($pair, ':');
                 $equal = mb_strpos($pair, '=');
 

--- a/tests/Everzet/Jade/JadeTest.php
+++ b/tests/Everzet/Jade/JadeTest.php
@@ -331,18 +331,18 @@ HTML;
         $this->assertEquals('<p class="foo"></p>',
             $this->parse("p(\"class\": 'foo')"), 'Keys with double quotes');
 
-//        $this->assertEquals(
-//          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
-//          $this->parse(
-//            "meta(name: 'viewport', content:\"width=device-width, user-scalable=no\")"
-//          ), 'Commas in attrs'
-//        );
-//        $this->assertEquals(
-//          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
-//          $this->parse(
-//            "meta(name: 'viewport', content:'width=device-width, user-scalable=no')"
-//          ), 'Commas in attrs'
-//        );
+        $this->assertEquals(
+          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
+          $this->parse(
+            "meta(name: 'viewport', content:\"width=device-width\\, user-scalable=no\")"
+          ), 'Commas in attrs'
+        );
+        $this->assertEquals(
+          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
+          $this->parse(
+            "meta(name: 'viewport', content:'width=device-width\\, user-scalable=no')"
+          ), 'Commas in attrs'
+        );
     }
     
     public function testCodeAttrs()


### PR DESCRIPTION
Escape commas in attribute values to avoid them being thrown as separate attributes
