### PR TITLE
Avoid cache filename collision.

### DIFF
--- a/src/Everzet/Jade/Jade.php
+++ b/src/Everzet/Jade/Jade.php
@@ -105,7 +105,7 @@ class Jade
     protected function getInputCacheKey($input)
     {
         if (is_file($input)) {
-            return basename($input, '.jade');
+            return str_replace('/', '.', substr($input, 1));
         } else {
             throw new \InvalidArgumentException('Only file templates can be cached.');
         }

--- a/src/Everzet/Jade/Lexer/Lexer.php
+++ b/src/Everzet/Jade/Lexer/Lexer.php
@@ -308,12 +308,13 @@ class Lexer implements LexerInterface
             $index      = $this->getDelimitersIndex('(', ')');
             $input      = mb_substr($this->input, 1, $index - 1);
             $token      = $this->takeToken('attributes', $input);
-            $attributes = preg_split('/ *, *(?=[\'"\w-]+ *[:=]|[\w-]+ *$)/', $token->value);
+            $attributes = preg_split('/ *(?<!\\\\), *(?=[\'"\w-]+ *[:=]|[\w-]+ *$)/', $token->value);
             $this->consumeInput($index + 1);
             $token->attributes = array();
 
             foreach ($attributes as $i => $pair) {
                 $pair = preg_replace('/^ *| *$/', '', $pair);
+                $pair = str_replace('\,', ',', $pair);
                 $colon = mb_strpos($pair, ':');
                 $equal = mb_strpos($pair, '=');
 

--- a/tests/Everzet/Jade/JadeTest.php
+++ b/tests/Everzet/Jade/JadeTest.php
@@ -331,18 +331,18 @@ HTML;
         $this->assertEquals('<p class="foo"></p>',
             $this->parse("p(\"class\": 'foo')"), 'Keys with double quotes');
 
-//        $this->assertEquals(
-//          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
-//          $this->parse(
-//            "meta(name: 'viewport', content:\"width=device-width, user-scalable=no\")"
-//          ), 'Commas in attrs'
-//        );
-//        $this->assertEquals(
-//          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
-//          $this->parse(
-//            "meta(name: 'viewport', content:'width=device-width, user-scalable=no')"
-//          ), 'Commas in attrs'
-//        );
+        $this->assertEquals(
+          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
+          $this->parse(
+            "meta(name: 'viewport', content:\"width=device-width\\, user-scalable=no\")"
+          ), 'Commas in attrs'
+        );
+        $this->assertEquals(
+          '<meta name="viewport" content="width=device-width, user-scalable=no" />',
+          $this->parse(
+            "meta(name: 'viewport', content:'width=device-width\\, user-scalable=no')"
+          ), 'Commas in attrs'
+        );
     }
     
     public function testCodeAttrs()


### PR DESCRIPTION
Better names for cache files.  This avoids collision when using repeated file names in different directories.

Ex: Cache for both files `/var/www/views/products/index.jade` and `/var/www/views/users/index.jade` would be stored in same cache file. Now they don't.
